### PR TITLE
update index.js according to react 18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
-  <React.StrictMode>
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(
+  <StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById("root")
+  </StrictMode>
 );


### PR DESCRIPTION
since you're using react 18, you should use the latest syntax provided in the official blog post about upgrading: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html

do check out a preview deployment to ensure everything is working. if its not, try removing the Strict Mode since it has gotten stricter in React 18.